### PR TITLE
Encoding strings to bytes be passed in calls inside get_remote()

### DIFF
--- a/metafil.py
+++ b/metafil.py
@@ -378,8 +378,8 @@ class GitEnv(object):
 			try:
 				return cmd_out.decode("utf-8").strip().split('https://')[1].split(' ')[0]
 			except IndexError:
-				ssh_url = cmd_out.strip().split('git@')[1].split(' ')[0]
-				return ssh_url.replace(':','/')
+				ssh_url = cmd_out.strip().split("git@".encode("utf-8"))[1].split(" ".encode("utf-8"))[0]
+				return ssh_url.replace(":".encode("utf-8"),"/".encode("utf-8"))
 		else:
 			return None
 

--- a/metafil.py
+++ b/metafil.py
@@ -378,8 +378,8 @@ class GitEnv(object):
 			try:
 				return cmd_out.decode("utf-8").strip().split('https://')[1].split(' ')[0]
 			except IndexError:
-				ssh_url = cmd_out.strip().split("git@".encode("utf-8"))[1].split(" ".encode("utf-8"))[0]
-				return ssh_url.replace(":".encode("utf-8"),"/".encode("utf-8"))
+				ssh_url = cmd_out.decode("utf-8").strip().split("git@")[1].split(" ")[0]
+				return ssh_url.replace(":","/")
 		else:
 			return None
 


### PR DESCRIPTION
metafil was having issues for with functions that apparently require bytes objects instead of strings. This PR encodes the strings to bytes object by passing `.encode("utf-8"')` after said strings. 
We might need to check the other side of the condition.